### PR TITLE
Make ccnl_fmri_con work for full regressor names

### DIFF
--- a/ccnl_fmri_con.m
+++ b/ccnl_fmri_con.m
@@ -25,11 +25,14 @@ function ccnl_fmri_con(EXPT,model,contrasts,subjects)
             con = regexp(contrasts{j},'-','split');
             for c = 1:length(con)
                 con{c} = strtrim(con{c});
+                found = false;
                 for i = 1:length(SPM.xX.name)
-                    if ~isempty(strfind(SPM.xX.name{i},[' ',con{c},'*'])) || ~isempty(strfind(SPM.xX.name{i},['x',con{c},'^']))
+                    if isequal(strfind(SPM.xX.name{i},[con{c},'*']), 1) || ~isempty(strfind(SPM.xX.name{i},[' ',con{c},'*'])) || ~isempty(strfind(SPM.xX.name{i},['x',con{c},'^']))
                         convec(j,i) = C(c);
+                        found = true;
                     end
                 end
+                assert(found, ['Cannot find regressor ', con{c}]);
             end
             matlabbatch{1}.spm.stats.con.consess{j}.tcon.name = contrasts{j};
             matlabbatch{1}.spm.stats.con.consess{j}.tcon.convec = convec(j,:);


### PR DESCRIPTION
Previously I made a change that fixes a bug in ccnl_fmri_con for
regressors that are prefixes of other regressors (e.g. 'feedback_onset', 'before_feedback_onset')
But this broke the edge case when we want to include the full
regressor name including the session number (e.g. 'Sn(1) feedback_onset') which we need to do to get the t-maps.
Here I'm adding a special case for this.

also tested it on the cluster